### PR TITLE
Add support for Python 2.7 and 3.4 using six

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,27 @@
+*************************************
+jcconv, Japanese Characters CONVerter
+*************************************
+
+jcconv, Japanese Characters CONVerter, interconvert hiragana, katakana, half-width kana.
+This module also treat 'half/wide number', 'half/wide alphabet'.
+
+Since 0.2.0, check_hira, check_kata, check_half functions were added.
+you can check if string consists of characters you specified.
+
+IMPOTANT: In current version, this works only with utf-8 encoding.
+
+Simple example of usage is followings
+
+.. code-block:: python
+
+    >>> from jcconv import *
+    >>> print hira2kata('あいうえお')   # hiragana to katakana
+    アイウエオ
+    >>> print kata2hira('カタカナ')     # katakana to hiragana
+    かたかな
+    >>> print half2hira('ﾊﾝｶｸｶﾀｶﾅ')      # half-width kana to hiragana
+    はんかくかたかな
+    >>> print half2wide('hello jcconv') # half-width alphabet to wide-width
+    ｈｅｌｌｏ ｊｃｃｏｎｖ
+    >>> print wide2half('ＷＩＤＥ')     # wide-width alphabet to half-width
+    wide

--- a/jcconv/__init__.py
+++ b/jcconv/__init__.py
@@ -25,8 +25,10 @@
        wide
 """
 
+from pkg_resources import get_distribution
+
 __author__  = "Matsumoto Taichi"
-__version__ = "0.2.3"
+__version__ = get_distribution('jcconv').version
 __license__ = "MIT License"
 
-from jcconv import *
+from .jcconv import *

--- a/jcconv/jcconv.py
+++ b/jcconv/jcconv.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 __all__ = ['hira2kata', 'kata2hira', 'half2hira', 'hira2half', 'kata2half',
            'half2kata', 'half2wide', 'wide2half', 'convert',
@@ -87,7 +88,7 @@ def convert(text, frm, to, reserved=[]):
             text = _multiple_replace(text, conv_table)
         return uflag and text or text.encode('utf-8')
     else:
-        raise "Invalid Parameter"
+        raise ValueError("Invalid Parameter")
 
 def check(text, char_set_type):
     uflag = isinstance(text, text_type)

--- a/jcconv/jcconv.py
+++ b/jcconv/jcconv.py
@@ -5,6 +5,7 @@ __all__ = ['hira2kata', 'kata2hira', 'half2hira', 'hira2half', 'kata2half',
            'check_hira', 'check_kata', 'check_half']
 
 import re
+from six import text_type
 
 # convert hiragana to katakana
 def hira2kata(text, reserved=[]):
@@ -70,7 +71,7 @@ def convert(text, frm, to, reserved=[]):
             return dic[match.group(0)]
         return rx.sub(proc_one, text)
 
-    uflag = isinstance(text, unicode)
+    uflag = isinstance(text, text_type)
     f_set = jcconv.char_sets[frm]
     t_set = jcconv.char_sets[to]
 
@@ -89,7 +90,7 @@ def convert(text, frm, to, reserved=[]):
         raise "Invalid Parameter"
 
 def check(text, char_set_type):
-    uflag = isinstance(text, unicode)
+    uflag = isinstance(text, text_type)
     text = uflag and text or text.decode('utf-8')
     char_set = []
     for set in jcconv.char_sets[char_set_type]:
@@ -124,13 +125,13 @@ class jcconv:
 if __name__ == '__main__':
     import codecs, sys
     sys.stdout = codecs.getwriter('utf_8')(sys.stdout)
-    
-    print convert(u'あいうえお', jcconv.HIRA, jcconv.HALF, [u'う'])
-    print convert(u'ばいおりん', jcconv.HIRA, jcconv.HALF)
-    print convert(u'ﾊﾞｲｵﾘﾝ', jcconv.HALF, jcconv.HIRA)
-    print convert(u'12345', jcconv.HNUM, jcconv.WNUM)
 
-    print check_hira(u'ひらがな')
-    print check_hira(u'カタカナ')
-    print check_kata(u'ひらがな')
-    print check_kata(u'カタカナ')
+    print(convert(u'あいうえお', jcconv.HIRA, jcconv.HALF, [u'う']))
+    print(convert(u'ばいおりん', jcconv.HIRA, jcconv.HALF))
+    print(convert(u'ﾊﾞｲｵﾘﾝ', jcconv.HALF, jcconv.HIRA))
+    print(convert(u'12345', jcconv.HNUM, jcconv.WNUM))
+
+    print(check_hira(u'ひらがな'))
+    print(check_hira(u'カタカナ'))
+    print(check_kata(u'ひらがな'))
+    print(check_kata(u'カタカナ'))

--- a/jcconv/jcconv_test.py
+++ b/jcconv/jcconv_test.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from jcconv import *
+from .jcconv import *
 
 class JcconvTest(unittest.TestCase):
     def testKana(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,34 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup
-import sys
-import unittest
+import os
 
-import jcconv
-from jcconv import __version__, __license__, __author__
+## Get long_description from index.txt:
+f = open(os.path.join('README.rst'))
+long_description = f.read().strip()
+f.close()
+
 
 if __name__ == '__main__':
-  from jcconv import jcconv_test
-  # run module test
-  loader = unittest.TestLoader()
-  result = unittest.TestResult()
-  suite  = loader.loadTestsFromModule(jcconv_test)
-  suite.run(result)
-  if not result.wasSuccessful():
-    print "unit tests have failed!"
-    print "aborted to make a source distribution"
-    sys.exit(1)
-
   # build distribution package
   setup(
     packages         = ('jcconv',),
     name             = 'jcconv',
-    version          = __version__,
+    version          = '0.2.3',
     py_modules       = ['jcconv', 'jcconv_test'],
     description      = 'jcconv "JapaneseCharacterCONVerter", interconvert hiragana, katakana, halfwidth kana',
-    long_description = jcconv.__doc__,
-    author           = __author__,
+    long_description = long_description,
+    author           = 'Matsumoto Taichi',
     author_email     = 'taichino@gmail.com',
     url              = 'http://github.com/taichino/jcconv',
     keywords         = 'japanese converter, hiragana, katakana, half-width kana',
-    license          = __license__,
+    license          = 'MIT License',
     classifiers      = ["Development Status :: 3 - Alpha",
                         "Intended Audience :: Developers",
                         "License :: OSI Approved :: MIT License",
                         "Operating System :: POSIX",
                         "Programming Language :: Python",
-                        "Topic :: Software Development :: Libraries :: Python Modules"]
+                        "Topic :: Software Development :: Libraries :: Python Modules"],
+    tests_require = ['six'],
+    test_suite = "jcconv.jcconv_test",
+    install_requires = ['six'],
     )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import with_statement
+
 from setuptools import setup
+import codecs
 import os
 
-## Get long_description from index.txt:
-f = open(os.path.join('README.rst'))
-long_description = f.read().strip()
-f.close()
+with codecs.open(os.path.join('README.rst'), encoding='utf-8') as f:
+    long_description = f.read().strip()
 
 
 if __name__ == '__main__':
@@ -26,7 +27,14 @@ if __name__ == '__main__':
                         "Intended Audience :: Developers",
                         "License :: OSI Approved :: MIT License",
                         "Operating System :: POSIX",
-                        "Programming Language :: Python",
+                        "Programming Language :: Python :: 2",
+                        "Programming Language :: Python :: 2.5",
+                        "Programming Language :: Python :: 2.6",
+                        "Programming Language :: Python :: 2.7",
+                        "Programming Language :: Python :: 3",
+                        "Programming Language :: Python :: 3.3",
+                        "Programming Language :: Python :: 3.4",
+                        "Programming Language :: Python :: 3.5",
                         "Topic :: Software Development :: Libraries :: Python Modules"],
     tests_require = ['six'],
     test_suite = "jcconv.jcconv_test",


### PR DESCRIPTION
Hi!

I've ported the package to support Python 3.4 using six. Installation works in 2.7 and 3.4 and tests passes in both versions.

The changes are minimal on the code but I had to change the setup.py file to install six as a dependency. Also I had to remove the execution of the tests previous to the installation because when setup.py is executed, six still is not installed. Tests can be executed with:

```
python setup.py test
```

Finally I added a README file, that is also used as the long_description field.

Hope you find it useful.
